### PR TITLE
Update Get Started button styles on landing page

### DIFF
--- a/src/components/examples/LandingPage.tsx
+++ b/src/components/examples/LandingPage.tsx
@@ -47,7 +47,7 @@ export function LandingPage({
           </h1>
           <p className="text-xl text-muted-foreground max-w-2xl">{heroDescription}</p>
           <div className="flex flex-col sm:flex-row gap-4">
-            <Button size="lg" className="text-white! bg-black! hover:bg-gray/90!">
+            <Button size="lg" className="bg-primary text-primary-foreground hover:bg-primary/90">
               Get Started
             </Button>
             <Button size="lg" variant="outline">

--- a/src/components/examples/LandingPage.tsx
+++ b/src/components/examples/LandingPage.tsx
@@ -48,7 +48,7 @@ export function LandingPage({
           <p className="text-xl text-muted-foreground max-w-2xl">{heroDescription}</p>
           <div className="flex flex-col sm:flex-row gap-4">
             <Button size="lg" className="bg-primary text-primary-foreground hover:bg-primary/90">
-              Get Started
+Hire SSW
             </Button>
             <Button size="lg" variant="outline">
               Learn More


### PR DESCRIPTION
Replaces custom class names with standardized 'bg-primary' and 'text-primary-foreground' for the Get Started button, improving consistency and maintainability of button styling.